### PR TITLE
fix: unused index

### DIFF
--- a/src/node/data/actions.ts
+++ b/src/node/data/actions.ts
@@ -43,7 +43,6 @@ async function createIndexes() {
       [
         { key: { type: 1, scheduled_for: 1 } },
         { key: { type: 1, status: 1, scheduled_for: 1 } },
-        { key: { type: 1, status: 1, worker_id: 1, started_at: 1 } },
         { key: { type: 1, name: 1 } },
         { key: { status: 1 } },
         {


### PR DESCRIPTION
- following index review within LBA, one index is not used. `https://github.com/mission-apprentissage/labonnealternance/pull/1775`
- `ended_at` is also unused but has a TTL 